### PR TITLE
Individual key for each particle for sampling inside `eltwise_grad_theta_likelihood`

### DIFF
--- a/dibs/inference/dibs.py
+++ b/dibs/inference/dibs.py
@@ -502,7 +502,7 @@ class DiBS:
     # (i.e. w.r.t the conditional distribution parameters)
     #
 
-    def eltwise_grad_theta_likelihood(self, zs, thetas, t, subk):
+    def eltwise_grad_theta_likelihood(self, zs, thetas, t, subkeys):
         """
         Computes batch of estimators for the score   :math:`\\nabla_{\\Theta} \\log p(\\Theta, D | Z)`,
         i.e. w.r.t the conditional distribution parameters.
@@ -520,7 +520,7 @@ class DiBS:
             batch of gradients in form of ``thetas`` PyTree with ``n_particles`` as leading dim
 
         """
-        return vmap(self.grad_theta_likelihood, (0, 0, None, None), 0)(zs, thetas, t, subk)
+        return vmap(self.grad_theta_likelihood, (0, 0, None, 0), 0)(zs, thetas, t, subkeys)
 
 
     def grad_theta_likelihood(self, single_z, single_theta, t, subk):

--- a/dibs/inference/svgd.py
+++ b/dibs/inference/svgd.py
@@ -667,8 +667,8 @@ class JointDiBS(DiBS):
         n_particles = z.shape[0]
 
         # d/dtheta log p(theta, D | z)
-        key, subk = random.split(key)
-        dtheta_log_prob = self.eltwise_grad_theta_likelihood(z, theta, t, subk)
+        key, *batch_subk = random.split(key, n_particles + 1)
+        dtheta_log_prob = self.eltwise_grad_theta_likelihood(z, theta, t, jnp.array(batch_subk))
 
         # d/dz log p(theta, D | z)
         key, *batch_subk = random.split(key, n_particles + 1)


### PR DESCRIPTION
Fix: Split the key correctly to have individual subkeys for each particle when computing the score gradient for the parameters theta inside one SVGD step. Previously, same key was used for each particle.