### PR TITLE
Fix bug in MarginalDiBS.get_empirical

### DIFF
--- a/dibs/inference/svgd.py
+++ b/dibs/inference/svgd.py
@@ -344,7 +344,7 @@ class MarginalDiBS(DiBS):
         # empirical distribution using counts
         logp = jnp.log(counts) - jnp.log(N)
 
-        return ParticleDistribution(logp=logp, g=g)
+        return ParticleDistribution(logp=logp, g=unique)
 
     def get_mixture(self, g):
         """


### PR DESCRIPTION
otherwise, length of `ParticleDistribution.logp` and `ParticleDistribution.g` are not consistent