### PR TITLE
split graph_model out of inference_model and rename latter to likelihood model

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ key = random.PRNGKey(0)
 
 # simulate some data
 key, subk = random.split(key)
-data, model = make_nonlinear_gaussian_model(key=subk, n_vars=20)
+data, graph_model, likelihood_model = make_nonlinear_gaussian_model(key=subk, n_vars=20)
 
 # sample 10 DAG and parameter particles from the joint posterior
-dibs = JointDiBS(x=data.x, interv_mask=None, inference_model=model)
+dibs = JointDiBS(x=data.x, interv_mask=None, graph_model=graph_model, likelihood_model=likelihood_model)
 key, subk = random.split(key)
 gs, thetas = dibs.sample(key=subk, n_particles=10, steps=1000)
 ```

--- a/dibs/inference/dibs.py
+++ b/dibs/inference/dibs.py
@@ -26,7 +26,7 @@ class DiBS:
         log_joint_prob (callable):
             function implementing joint likelihood :math:`\\log p(\Theta, D | G)`
             of parameters and observations given the discrete graph adjacency matrix
-            For example: :func:`dibs.models.LinearGaussian.observational_log_joint_prob`.
+            For example: :func:`dibs.models.LinearGaussian.interventional_log_joint_prob`.
             When inferring the marginal posterior :math:`p(G | D)` via a closed-form
             marginal likelihood :math:`\\log p(D | G)`, the same function signature has to be
             satisfied (simply ignoring :math:`\\Theta`)

--- a/dibs/inference/svgd.py
+++ b/dibs/inference/svgd.py
@@ -29,10 +29,12 @@ class MarginalDiBS(DiBS):
         x (ndarray): observations of shape ``[n_observations, n_vars]``
         interv_mask (ndarray, optional): binary matrix of shape ``[n_observations, n_vars]`` indicating
             whether a given variable was intervened upon in a given sample (intervention = 1, no intervention = 0)
-        inference_model: Bayes net inference model defining prior :math:`\\log p(G)`
-            and marginal likelihood :math:`\\log p(D | G)`` underlying the inferred posterior.
-            Object *has to implement two methods*:
-            ``log_graph_prior`` and ``observational_log_marginal_prob``.
+        graph_model: Model defining the prior :math:`\\log p(G)` underlying the inferred posterior.
+            Object *has to implement one method*: ``unnormalized_log_prob_soft``
+            Example: :class:`~dibs.models.ErdosReniDAGDistribution`
+        likelihood_model: Model defining the marginal likelihood :math:`\\log p(D | G)``
+            underlying the inferred posterior.
+            Object *has to implement one method*: ``interventional_log_marginal_prob``
             Example: :class:`~dibs.models.BGe`
         kernel: Class of kernel. *Has to implement the method* ``eval(u, v)``.
             Example: :class:`~dibs.kernel.AdditiveFrobeniusSEKernel`
@@ -57,7 +59,8 @@ class MarginalDiBS(DiBS):
 
     def __init__(self, *,
                  x,
-                 graph_model, likelihood_model,
+                 graph_model,
+                 likelihood_model,
                  interv_mask=None,
                  kernel=AdditiveFrobeniusSEKernel,
                  kernel_param=None,
@@ -389,10 +392,13 @@ class JointDiBS(DiBS):
         x (ndarray): observations of shape ``[n_observations, n_vars]``
         interv_mask (ndarray, optional): binary matrix of shape ``[n_observations, n_vars]`` indicating
             whether a given variable was intervened upon in a given sample (intervention = 1, no intervention = 0)
-        inference_model: Bayes net inference model defining prior :math:`\\log p(G)`
-            and joint likelihood :math:`\\log p(\\Theta, D | G) = \\log p(\\Theta | G) + \\log p(D | G, \\Theta``
-            underlying the inferred posterior. Object *has to implement two methods*:
-            ``log_graph_prior`` and ``observational_log_joint_prob``.
+        graph_model: Model defining the prior :math:`\\log p(G)` underlying the inferred posterior.
+            Object *has to implement one method*: ``unnormalized_log_prob_soft``
+            Example: :class:`~dibs.models.ErdosReniDAGDistribution`
+        likelihood_model: Model defining the joint likelihood
+            :math:`\\log p(\\Theta, D | G) = \\log p(\\Theta | G) + \\log p(D | G, \\Theta)``
+            underlying the inferred posterior.
+            Object *has to implement one method*: ``interventional_log_joint_prob``
             Example: :class:`~dibs.models.LinearGaussian`
         kernel: Class of kernel. *Has to implement the method* ``eval(u, v)``.
             Example: :class:`~dibs.kernel.JointAdditiveFrobeniusSEKernel`
@@ -418,7 +424,8 @@ class JointDiBS(DiBS):
 
     def __init__(self, *,
                  x,
-                 inference_model,
+                 graph_model,
+                 likelihood_model,
                  interv_mask=None,
                  kernel=JointAdditiveFrobeniusSEKernel,
                  kernel_param=None,

--- a/dibs/models/nonlinearGaussian.py
+++ b/dibs/models/nonlinearGaussian.py
@@ -90,10 +90,7 @@ class DenseNonlinearGaussian:
     Refer to http://proceedings.mlr.press/v108/zheng20a/zheng20a.pdf
 
     Args:
-        graph_dist: Graph model defining prior :math:`\\log p(G)`. Object *has to implement the method*:
-            ``unnormalized_log_prob_soft``.
-            For example: :class:`~dibs.graph.ErdosReniDAGDistribution`
-            or :class:`~dibs.graph.ScaleFreeDAGDistribution`
+        n_vars (int): number of variables (nodes in the graph)
         hidden_layers (list): list of integers specifying the number of layers as well as their widths.
             For example: ``[8, 8]`` would correspond to 2 hidden layers with 8 neurons
         obs_noise (float, optional): variance of additive observation noise at nodes
@@ -102,9 +99,8 @@ class DenseNonlinearGaussian:
             Choices: ``sigmoid``, ``tanh``, ``relu``, ``leakyrelu``
 
     """
-    def __init__(self, *, graph_dist, hidden_layers, obs_noise=0.1, sig_param=1.0, activation='relu', bias=True):
-        self.graph_dist = graph_dist
-        self.n_vars = graph_dist.n_vars
+    def __init__(self, *, n_vars, hidden_layers, obs_noise=0.1, sig_param=1.0, activation='relu', bias=True):
+        self.n_vars = n_vars
         self.obs_noise = obs_noise
         self.sig_param = sig_param
         self.hidden_layers = hidden_layers
@@ -308,19 +304,6 @@ class DenseNonlinearGaussian:
     """
     Distributions used by DiBS for inference:  prior and joint likelihood 
     """
-
-    def log_graph_prior(self, g_prob):
-        """ Computes graph prior :math:`\\log p(G)` given matrix of edge probabilities.
-        This function simply binds the function of the provided ``self.graph_dist``.
-
-        Arguments:
-            g_prob (ndarray): edge probabilities in G of shape ``[n_vars, n_vars]``
-
-        Returns:
-            log prob
-        """
-        return self.graph_dist.unnormalized_log_prob_soft(soft_g=g_prob)
-
 
     def interventional_log_joint_prob(self, g, theta, x, interv_targets, rng):
         """Computes interventional joint likelihood :math:`\\log p(\\Theta, D | G)``

--- a/dibs/target.py
+++ b/dibs/target.py
@@ -36,7 +36,7 @@ class Data(NamedTuple):
     g: Any
     theta: Any
     x: Any
-    x_ho :Any
+    x_ho: Any
     x_interv: Any
 
 
@@ -180,11 +180,11 @@ def make_linear_gaussian_equivalent_model(*, key, n_vars=20, graph_prior_str='sf
     graph_dist = make_graph_model(n_vars=n_vars, graph_prior_str=graph_prior_str)
 
     generative_model = LinearGaussian(
-        graph_dist=graph_dist, obs_noise=obs_noise,
+        n_vars=n_vars, obs_noise=obs_noise,
         mean_edge=mean_edge, sig_edge=sig_edge,
         min_edge=min_edge)
 
-    inference_model = BGe(graph_dist=graph_dist)
+    likelihood_model = BGe(graph_dist=graph_dist)
 
     # sample synthetic BN and observations
     key, subk = random.split(key)
@@ -195,7 +195,7 @@ def make_linear_gaussian_equivalent_model(*, key, n_vars=20, graph_prior_str='sf
         n_observations=n_observations,
         n_ho_observations=n_ho_observations)
 
-    return data, inference_model
+    return data, graph_dist, likelihood_model
 
 
 def make_linear_gaussian_model(*, key, n_vars=20, graph_prior_str='sf', 
@@ -224,12 +224,12 @@ def make_linear_gaussian_model(*, key, n_vars=20, graph_prior_str='sf',
     graph_dist = make_graph_model(n_vars=n_vars, graph_prior_str=graph_prior_str)
 
     generative_model = LinearGaussian(
-        graph_dist=graph_dist, obs_noise=obs_noise,
+        n_vars=n_vars, obs_noise=obs_noise,
         mean_edge=mean_edge, sig_edge=sig_edge,
         min_edge=min_edge)
 
-    inference_model = LinearGaussian(
-        graph_dist=graph_dist, obs_noise=obs_noise,
+    likelihood_model = LinearGaussian(
+        n_vars=n_vars, obs_noise=obs_noise,
         mean_edge=mean_edge, sig_edge=sig_edge,
         min_edge=min_edge)
 
@@ -242,7 +242,7 @@ def make_linear_gaussian_model(*, key, n_vars=20, graph_prior_str='sf',
         n_observations=n_observations,
         n_ho_observations=n_ho_observations)
 
-    return data, inference_model
+    return data, graph_dist, likelihood_model
 
 
 def make_nonlinear_gaussian_model(*, key, n_vars=20, graph_prior_str='sf', 
@@ -274,12 +274,12 @@ def make_nonlinear_gaussian_model(*, key, n_vars=20, graph_prior_str='sf',
     graph_dist = make_graph_model(n_vars=n_vars, graph_prior_str=graph_prior_str)
 
     generative_model = DenseNonlinearGaussian(
-        obs_noise=obs_noise, sig_param=sig_param,
-        hidden_layers=hidden_layers, graph_dist=graph_dist)
+        n_vars=n_vars, hidden_layers=hidden_layers,
+        obs_noise=obs_noise, sig_param=sig_param)
 
-    inference_model = DenseNonlinearGaussian(
-        obs_noise=obs_noise, sig_param=sig_param,
-        hidden_layers=hidden_layers, graph_dist=graph_dist)
+    likelihood_model = DenseNonlinearGaussian(
+        n_vars=n_vars, hidden_layers=hidden_layers,
+        obs_noise=obs_noise, sig_param=sig_param)
 
     # sample synthetic BN and observations
     key, subk = random.split(key)
@@ -290,4 +290,4 @@ def make_nonlinear_gaussian_model(*, key, n_vars=20, graph_prior_str='sf',
         n_observations=n_observations,
         n_ho_observations=n_ho_observations)
 
-    return data, inference_model
+    return data, graph_dist, likelihood_model

--- a/examples/dibs_joint.ipynb
+++ b/examples/dibs_joint.ipynb
@@ -58,8 +58,8 @@
     "from dibs.utils import visualize_ground_truth\n",
     "\n",
     "key, subk = random.split(key)\n",
-    "data, model = make_linear_gaussian_model(key=subk, n_vars=20, graph_prior_str=\"sf\")\n",
-    "# data, model = make_nonlinear_gaussian_model(key=subk, n_vars=20, graph_prior_str=\"sf\")\n",
+    "data, graph_model, likelihood_model = make_linear_gaussian_model(key=subk, n_vars=20, graph_prior_str=\"sf\")\n",
+    "# data, graph_model, likelihood_model = make_nonlinear_gaussian_model(key=subk, n_vars=20, graph_prior_str=\"sf\")\n",
     "\n",
     "visualize_ground_truth(data.g)"
    ]
@@ -71,7 +71,7 @@
    "source": [
     "### DiBS with SVGD\n",
     "\n",
-    "Infer $p(G, \\Theta | D)$ under the prior and conditional distributions defined by `model`.\n",
+    "Infer $p(G, \\Theta | D)$ under the prior and conditional distributions defined by the model.\n",
     "The below visualization shows the *matrix of edge probabilities* $G_\\alpha(Z^{(k)})$ implied by each transported latent particle (i.e., sample) $Z^{(k)}$ during the iterations of SVGD with DiBS. Refer to the paper for further details.\n",
     "\n",
     "To explicitly perform posterior inference of $p(G | \\mathcal{D})$ using a closed-form marginal likelihood $p(D | G)$, use the separate, analogous class `MarginalDiBS` as demonstrated in the example notebook `dibs_marginal.ipynb`.\n",
@@ -89,7 +89,7 @@
    "source": [
     "from dibs.inference import JointDiBS\n",
     "\n",
-    "dibs = JointDiBS(x=data.x, interv_mask=None, inference_model=model)\n",
+    "dibs = JointDiBS(x=data.x, interv_mask=None, graph_model=graph_model, likelihood_model=likelihood_model)\n",
     "key, subk = random.split(key)\n",
     "gs, thetas = dibs.sample(key=subk, n_particles=20, steps=2000, callback_every=20, callback=dibs.visualize_callback())"
    ]

--- a/examples/dibs_joint_colab.ipynb
+++ b/examples/dibs_joint_colab.ipynb
@@ -76,8 +76,8 @@
     "from dibs.utils import visualize_ground_truth\n",
     "\n",
     "key, subk = random.split(key)\n",
-    "data, model = make_linear_gaussian_model(key=subk, n_vars=20, graph_prior_str=\"sf\")\n",
-    "# data, model = make_nonlinear_gaussian_model(key=subk, n_vars=20, graph_prior_str=\"sf\")\n",
+    "data, graph_model, likelihood_model = make_linear_gaussian_model(key=subk, n_vars=20, graph_prior_str=\"sf\")\n",
+    "# data, graph_model, likelihood_model = make_nonlinear_gaussian_model(key=subk, n_vars=20, graph_prior_str=\"sf\")\n",
     "\n",
     "visualize_ground_truth(data.g)"
    ]
@@ -89,7 +89,7 @@
    "source": [
     "### DiBS with SVGD\n",
     "\n",
-    "Infer $p(G, \\Theta | D)$ under the prior and conditional distributions defined by `model`.\n",
+    "Infer $p(G, \\Theta | D)$ under the prior and conditional distributions defined by the model.\n",
     "The below visualization shows the *matrix of edge probabilities* $G_\\alpha(Z^{(k)})$ implied by each transported latent particle (i.e., sample) $Z^{(k)}$ during the iterations of SVGD with DiBS. Refer to the paper for further details.\n",
     "\n",
     "To explicitly perform posterior inference of $p(G | \\mathcal{D})$ using a closed-form marginal likelihood $p(D | G)$, use the separate, analogous class `MarginalDiBS` as demonstrated in the example notebook `dibs_marginal.ipynb`\n",
@@ -107,7 +107,7 @@
    "source": [
     "from dibs.inference import JointDiBS\n",
     "\n",
-    "dibs = JointDiBS(x=data.x, interv_mask=None, inference_model=model)\n",
+    "dibs = JointDiBS(x=data.x, interv_mask=None, graph_model=graph_model, likelihood_model=likelihood_model)\n",
     "key, subk = random.split(key)\n",
     "gs, thetas = dibs.sample(key=subk, n_particles=20, steps=2000, callback_every=100, callback=dibs.visualize_callback())"
    ]

--- a/examples/dibs_marginal.ipynb
+++ b/examples/dibs_marginal.ipynb
@@ -56,7 +56,7 @@
     "from dibs.utils import visualize_ground_truth\n",
     "\n",
     "key, subk = random.split(key)\n",
-    "data, model = make_linear_gaussian_equivalent_model(key=subk, n_vars=20, graph_prior_str=\"sf\")\n",
+    "data, graph_model, likelihood_model = make_linear_gaussian_equivalent_model(key=subk, n_vars=20, graph_prior_str=\"sf\")\n",
     "\n",
     "visualize_ground_truth(data.g)"
    ]
@@ -68,7 +68,7 @@
    "source": [
     "### DiBS with SVGD\n",
     "\n",
-    "Infer $p(G | D)$ under the prior and marginal likelihood defined by `model`.\n",
+    "Infer $p(G | D)$ under the prior and marginal likelihood defined by the model.\n",
     "The below visualization shows the *matrix of edge probabilities* $G_\\alpha(Z^{(k)})$ implied by each transported latent particle (i.e., sample) $Z^{(k)}$ during the iterations of SVGD with DiBS. Refer to the paper for further details.\n",
     "\n",
     "To explicitly perform joint posterior inference of $p(G, \\Theta | \\mathcal{D})$ using a general likelihood $p(x | G, \\Theta)$, use the separate, analogous class `JointDiBS`.\n",
@@ -87,7 +87,7 @@
     "%%time\n",
     "from dibs.inference import MarginalDiBS\n",
     "\n",
-    "dibs = MarginalDiBS(x=data.x, interv_mask=None, inference_model=model)\n",
+    "dibs = MarginalDiBS(x=data.x, interv_mask=None, graph_model=graph_model, likelihood_model=likelihood_model)\n",
     "key, subk = random.split(key)\n",
     "gs = dibs.sample(key=subk, n_particles=20, steps=2000, callback_every=20, callback=dibs.visualize_callback())"
    ]

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 setup(
     name='dibs-lib',
-    version='1.2.0',
+    version='1.3.0',
     description='DiBS: Differentiable Bayesian Structure Learning',
     author='Lars Lorch',
     author_email='lars.lorch@inf.ethz.ch',


### PR DESCRIPTION
As discussed in the thread https://github.com/larslorch/dibs/pull/4#discussion_r999290040

Thoughts while looking at the code, would be keen to hear your thoughts:
- There's a lot of duplication between JointDiBS and MarginalDiBS. This might be a case where it could be a lot easier to maintain if it's just one class, and a few `if has_theta:` clauses for theta-specific steps. Some functionality could be unified (e.g. instead of separate `_f_kernel(x_latent, y_latent)` and `_f_kernel(x_latent, x_theta, y_latent, y_theta)`, could it be just a single `_f_kernel(x_state, y_state)` where state might be a tuple `(latent, theta)`, and jax could map over both arguments simultaneously like in the tree_map?)
- It'd be great to separate out concerns, making more use of [composition over inheritance](https://en.wikipedia.org/wiki/Composition_over_inheritance) (more python-specific details in the excellent [Python Patterns Guide](https://python-patterns.guide/gang-of-four/composition-over-inheritance/)). For example, the current Joint/MarginalDiBS could take an instance of DiBS as its argument - then it doesn't have to pass through all those keyword arguments - and it can still access all the methods of that instance.